### PR TITLE
feat: add chirp-v5-5 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ done < prompts.txt
 
 | Model | Version | Max Duration | Notes |
 |-------|---------|-------------|-------|
-| `chirp-v5` | V5 | 8 min | Latest, best quality |
+| `chirp-v5-5` | V5.5 | 8 min | Latest, best quality |
+| `chirp-v5` | V5 | 8 min | High quality |
 | `chirp-v4-5-plus` | V4.5+ | 8 min | Enhanced quality |
 | `chirp-v4-5` | V4.5 | 4 min | Vocal gender control (default) |
 | `chirp-v4` | V4 | 150s | Stable |

--- a/suno_cli/core/output.py
+++ b/suno_cli/core/output.py
@@ -19,6 +19,7 @@ SUNO_MODELS = [
     "chirp-v4-5",
     "chirp-v4-5-plus",
     "chirp-v5",
+    "chirp-v5-5",
 ]
 
 DEFAULT_MODEL = "chirp-v4-5"
@@ -147,7 +148,8 @@ def print_models() -> None:
     table.add_column("Notes")
 
     models = [
-        ("chirp-v5", "V5", "8 min", "Latest, best quality"),
+        ("chirp-v5-5", "V5.5", "8 min", "Latest, best quality"),
+        ("chirp-v5", "V5", "8 min", "High quality"),
         ("chirp-v4-5-plus", "V4.5+", "8 min", "Enhanced quality"),
         ("chirp-v4-5", "V4.5", "4 min", "Vocal gender control (default)"),
         ("chirp-v4", "V4", "150s", "Stable"),

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -532,6 +532,7 @@ class TestInfoCommands:
     def test_models(self, runner):
         result = runner.invoke(cli, ["models"])
         assert result.exit_code == 0
+        assert "chirp-v5-5" in result.output
         assert "chirp-v5" in result.output
         assert "chirp-v4-5" in result.output
         assert "chirp-v3-0" in result.output

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -25,7 +25,7 @@ class TestConstants:
         assert DEFAULT_MODEL in SUNO_MODELS
 
     def test_models_include_all_versions(self):
-        for model in ["chirp-v3-0", "chirp-v4", "chirp-v4-5", "chirp-v5"]:
+        for model in ["chirp-v3-0", "chirp-v4", "chirp-v4-5", "chirp-v5", "chirp-v5-5"]:
             assert model in SUNO_MODELS
 
 
@@ -111,6 +111,7 @@ class TestPrintModels:
     def test_print_models(self, capsys):
         print_models()
         captured = capsys.readouterr()
+        assert "chirp-v5-5" in captured.out
         assert "chirp-v5" in captured.out
         assert "chirp-v4-5" in captured.out
         assert "chirp-v3-0" in captured.out


### PR DESCRIPTION
## Summary
Add support for the new Suno chirp-v5-5 model in SunoCli.

## Changes
- Add `chirp-v5-5` to `SUNO_MODELS` list in `core/output.py`
- Add `chirp-v5-5` to `print_models()` table display
- Update README model table
- Update tests to verify `chirp-v5-5` presence